### PR TITLE
Possibility to change root directory of Review Board

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ This container has two volume mount-points:
 
 The container accepts the following environment variables:
 
+- ```ROOT``` - Root directory for the Reviewboard. 
 - ```PGHOST``` - the postgres host. Defaults to the value of ```PG_PORT_5432_TCP_ADDR```, provided by the ```pg``` linked container.
 - ```PGPORT``` - the postgres port. Defaults to the value of ```PG_PORT_5432_TCP_PORT```, provided by the ```pg``` linked container, or 5432, if it's empty.
 - ```PGUSER``` - the postgres user. Defaults to ```reviewboard```.

--- a/start.sh
+++ b/start.sh
@@ -21,10 +21,17 @@ mkdir -p /var/www/
 
 CONFFILE=/var/www/reviewboard/conf/settings_local.py
 
+# Fix the path to work properly if not ending to /.
+if [ "x$ROOT" != "x" ] && [ "${ROOT: -1}" != "/" ]; then
+     ROOT=$ROOT/
+fi
+
+echo $ROOT
+
 if [[ ! -d /var/www/reviewboard ]]; then
     rb-site install --noinput \
         --domain-name="$DOMAIN" \
-        --site-root=/ --static-url=static/ --media-url=media/ \
+        --site-root="/$ROOT" --static-url="static/" --media-url=media/ \
         --db-type=postgresql \
         --db-name="$PGDB" \
         --db-host="$PGHOST" \

--- a/start.sh
+++ b/start.sh
@@ -26,8 +26,6 @@ if [ "x$ROOT" != "x" ] && [ "${ROOT: -1}" != "/" ]; then
      ROOT=$ROOT/
 fi
 
-echo $ROOT
-
 if [[ ! -d /var/www/reviewboard ]]; then
     rb-site install --noinput \
         --domain-name="$DOMAIN" \


### PR DESCRIPTION
I added ROOT -environment variable which is able to change the root directory of Review Board. It can't change the location of static files because it seems to be Review Board. This is useful in situation where I want to have reverse proxy at port 80 which is then using the Review Board at Docker. This is part of our security planning to protect the system from unauthorized access.
