### PR TITLE
Support changing site path with a environment variable SITE_ROOT.

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ The container accepts the following environment variables:
 - ```MEMCACHED``` - memcache address in format ```host:port```. Defaults to the value from linked ```memcached``` container.
 - ```DOMAIN``` - defaults to ```localhost```.
 - ```DEBUG``` - if set, the django server will be launched in debug mode.
+- ```SITE_ROOT``` - the path of the site, relative to the domain. This should start and end with a ```/```. For example, ```/reviews/```. Defaults to ```/```.
 
 Also, uwsgi accepts environment prefixed with ```UWSGI_``` for it's configuration
 E.g. ```-e UWSGI_PROCESSES=10``` will create 10 reviewboard processes.

--- a/start.sh
+++ b/start.sh
@@ -28,6 +28,16 @@ if [[  "${WAIT_FOR_POSTGRES}" = "true" ]]; then
 
 fi
 
+if [[ "${SITE_ROOT}" ]]; then
+    if [[ "${SITE_ROOT}" != "/" ]]; then
+        # Add trailing and leading slashes to SITE_ROOT if it's not there.
+        SITE_ROOT="${SITE_ROOT#/}"
+        SITE_ROOT="/${SITE_ROOT%/}/"
+    fi
+else
+    SITE_ROOT=/
+fi
+
 mkdir -p /var/www/
 
 CONFFILE=/var/www/reviewboard/conf/settings_local.py
@@ -35,7 +45,8 @@ CONFFILE=/var/www/reviewboard/conf/settings_local.py
 if [[ ! -d /var/www/reviewboard ]]; then
     rb-site install --noinput \
         --domain-name="$DOMAIN" \
-        --site-root=/ --static-url=static/ --media-url=media/ \
+        --site-root="$SITE_ROOT" \
+        --static-url=static/ --media-url=media/ \
         --db-type=postgresql \
         --db-name="$PGDB" \
         --db-host="$PGHOST" \
@@ -50,5 +61,7 @@ if [[ "${DEBUG}" ]]; then
     sed -i 's/DEBUG *= *False/DEBUG=True/' "$CONFFILE"
     cat "${CONFFILE}"
 fi
+
+export SITE_ROOT
 
 exec uwsgi --ini /uwsgi.ini

--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -5,8 +5,8 @@ pymodule-alias=settings_local=/var/www/reviewboard/conf/settings_local.py
 module = django.core.handlers.wsgi:WSGIHandler()
 master=true
 http=:8000
-static-map=/static=/var/www/reviewboard/htdocs/static
-static-map=/media=/var/www/reviewboard/htdocs/media
-static-map=/errordocs=/var/www/reviewboard/htdocs/errordocs
+static-map=$(SITE_ROOT)static=/var/www/reviewboard/htdocs/static
+static-map=$(SITE_ROOT)media=/var/www/reviewboard/htdocs/media
+static-map=$(SITE_ROOT)errordocs=/var/www/reviewboard/htdocs/errordocs
 static-safe=/usr/lib/python2.7/site-packages/
 enable-threads=true


### PR DESCRIPTION
Using reverse proxy I really want to change site path and bit disappointed with no progress for #6. So I have maid this request 😃

I tested these cases:

* without ```SITE_ROOT```
* ```SITE_ROOT = /```
* ```SITE_ROOT = foobar```
* ```SITE_ROOT = /foobar```
* ```SITE_ROOT = foobar/```
* ```SITE_ROOT = /foo/bar/```
