### PR TITLE
Update Dockerfile for latest version of ReviewBoard

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,8 @@ MAINTAINER igor.katson@gmail.com
 RUN yum install -y pyliblzma
 
 RUN yum install -y epel-release && \
-    yum install -y ReviewBoard-2.5.7 uwsgi RBTools \
+    yum install -y ReviewBoard-2.5.10 uwsgi \
       uwsgi-plugin-python python-ldap python-pip python2-boto && \
-    yum install -y https://kojipkgs.fedoraproject.org//packages/python-publicsuffix/1.1.0/1.el7/noarch/python2-publicsuffix-1.1.0-1.el7.noarch.rpm && \
-    yum install -y https://kojipkgs.fedoraproject.org//packages/python-djblets/0.9.4/3.el7/noarch/python-djblets-0.9.4-3.el7.noarch.rpm && \
     yum install -y postgresql && \
     yum clean all
 


### PR DESCRIPTION
I saw automated build [failed on dockerhub](https://hub.docker.com/r/ikatson/reviewboard/builds/) and fixed errors.

I fixed it locally for testing when I made last pull request so it worked for me.
However I'm not so sure that it is correct especially removing ```RBTools```.