### PR TITLE
remove reviewboard version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ MAINTAINER igor.katson@gmail.com
 RUN yum install -y pyliblzma
 
 RUN yum install -y epel-release && \
-    yum install -y ReviewBoard-2.5.10 uwsgi \
+    yum install -y ReviewBoard uwsgi \
       uwsgi-plugin-python python-ldap python-pip python2-boto && \
     yum install -y postgresql && \
     yum clean all


### PR DESCRIPTION
## Problem
reviewboard container built with `docker-compose build` doesn't start 

## Container log
```
/start.sh: line 24: rb-site: command not found
.
.
*** Operational MODE: single process ***
failed to open python file /var/www/reviewboard/conf/settings_local.py
```

## Description
`ReviewBoard-2.5.10` package is now not avaiable on CentOS 7. So `rb-site` command is not installed in reviewboard container built with `docker-compose build`.
simpliy removed version specifier ....  It works.

## Note
* current available ReviewBoard package version is `ReviewBoard-2.5.12-1.el7`
* yum doesn't fail if missing package is specified : https://serverfault.com/questions/694942/yum-should-error-when-a-package-is-not-available
  * In this case, `ReviewBoard-2.5.10` and `uwsgi` are specified to yum command, yum doesn't fail because `uwsgi` package exists.
 