### PR TITLE
Adding in note about Proxy settings in Docker file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,10 @@
 FROM centos:7
 MAINTAINER igor.katson@gmail.com
 
+# Proxy Settings
+ENV http_proxy proxy.esl.cisco.com:80
+ENV https_proxy proxy.esl.cisco.com:80
+
 # This is needed in for xz compression in case you can't install EPEL.
 # See https://github.com/ikatson/docker-reviewboard/issues/10
 RUN yum install -y pyliblzma

--- a/README.md
+++ b/README.md
@@ -121,3 +121,11 @@ For example, if you use ```postfix```, you should change ```/etc/postfix/main.cf
 
     mynetworks = 127.0.0.0/8 [::ffff:127.0.0.0]/104 [::1]/128 172.17.0.0/16
     inet_interfaces = 127.0.0.1,172.17.42.1
+
+### Proxy Settings
+If your server sits behind a proxy, you will mostly likely have issues downloading the packages. To get around this be sure to set the proxy settings within the Docker file.
+
+```
+ENV http_proxy proxy-address.com:port
+ENV https_proxy proxy-address.com:port
+```


### PR DESCRIPTION
I sometimes run into issues with servers sitting behind a firewall and it takes me a few failed attempts to figure out it is the proxy server settings. Consider adding a small note to the README.md file for users to quickly solve in future.