### PR TITLE
Fixes for pygments error in issue #26

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ MAINTAINER igor.katson@gmail.com
 RUN yum install -y pyliblzma
 
 RUN yum install -y epel-release && \
-    yum install -y ReviewBoard uwsgi \
+    yum install -y ReviewBoard python-pygments uwsgi \
       uwsgi-plugin-python python-ldap python-pip python2-boto && \
     yum install -y postgresql && \
     yum clean all


### PR DESCRIPTION
Installed:
  python-pygments.noarch 0:1.4-9.el7
>>> from pygments import highlight
>>>
works fine inside the docker container and the error goes away