### PR TITLE
Removed all centos7 stuff that breaks all the time and move to pip install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,12 +8,13 @@ RUN apt-get update -y && \
         uwsgi uwsgi-plugin-python \
         postgresql-client \
         python-psycopg2 \
-        git-core mercurial subversion python-svn
-
+        git-core mercurial subversion python-svn && \
+        rm -rf /var/lib/apt/lists/*
 
 RUN python -m virtualenv /opt/venv && \
     . /opt/venv/bin/activate && \
-    pip install ReviewBoard 'django-storages<1.3'
+    pip install ReviewBoard 'django-storages<1.3' && \
+    rm -rf /root/.cache
 
 ENV PATH="/opt/venv/bin:${PATH}"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,21 @@
-FROM centos:7
+FROM ubuntu:18.04
 MAINTAINER igor.katson@gmail.com
 
-# This is needed in for xz compression in case you can't install EPEL.
-# See https://github.com/ikatson/docker-reviewboard/issues/10
-RUN yum install -y pyliblzma
+RUN apt-get update -y && \
+    apt-get install --no-install-recommends -y \
+        build-essential python-dev libffi-dev libssl-dev patch \
+        python-pip python-setuptools python-wheel python-virtualenv \
+        uwsgi uwsgi-plugin-python \
+        postgresql-client \
+        python-psycopg2 \
+        git-core mercurial subversion python-svn
 
-RUN yum install -y epel-release && \
-    yum install -y ReviewBoard uwsgi \
-      uwsgi-plugin-python python-ldap python-pip python2-boto && \
-    yum install -y postgresql && \
-    yum clean all
 
-# ReviewBoard runs on django 1.6, so we need to use a compatible django-storages
-# version for S3 support.
-RUN pip install -U pip && \
-    rm -rf /usr/lib/python2.7/site-packages/Pygments-2.2.0-py2.7.egg && \
-    pip install 'pygments>2.0' 'django-storages<1.3'
+RUN python -m virtualenv /opt/venv && \
+    . /opt/venv/bin/activate && \
+    pip install ReviewBoard 'django-storages<1.3'
+
+ENV PATH="/opt/venv/bin:${PATH}"
 
 ADD start.sh /start.sh
 ADD uwsgi.ini /uwsgi.ini

--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -1,5 +1,7 @@
 [uwsgi]
 plugin=python,http
+home=/opt/venv/
+die-on-term=
 env=DJANGO_SETTINGS_MODULE=reviewboard.settings
 pymodule-alias=settings_local=/var/www/reviewboard/conf/settings_local.py
 module = django.core.handlers.wsgi:WSGIHandler()
@@ -8,5 +10,5 @@ http=:8000
 static-map=$(SITE_ROOT)static=/var/www/reviewboard/htdocs/static
 static-map=$(SITE_ROOT)media=/var/www/reviewboard/htdocs/media
 static-map=$(SITE_ROOT)errordocs=/var/www/reviewboard/htdocs/errordocs
-static-safe=/usr/lib/python2.7/site-packages/
+static-safe=/opt/venv/lib/python2.7/site-packages/
 enable-threads=true


### PR DESCRIPTION
As reviewboard now supports installation with "pip install", I did the following here:

- moved away from Centos7 to ubuntu:18.04 as centos epel installation broke all the time
- install ReviewBoard with pip, which should install the latest version
- install into a virtualenv not to interfere with system packages, as this caused trouble in the past

Thanks to @oleksiiseleznov for giving the idea to do this and providing an implementation on top of centos7 here https://github.com/ikatson/docker-reviewboard/pull/37

Hopefully, it will not break as often now.