### PR TITLE
Fix mountpoints and document usage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ ADD shell.sh /shell.sh
 
 RUN chmod +x start.sh shell.sh
 
-VOLUME ["/root/.ssh", "/media/"]
+VOLUME /var/www/
 
 EXPOSE 8000
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,8 +9,7 @@ services:
     reviewboard:
         build: ./
         volumes:
-            - /root/.ssh
-            - /media
+            - /var/www/
         depends_on:
             - postgres
             - memcached


### PR DESCRIPTION
Apparently the documentation got a bit outdated. All relevant data like .ssh keys and uploaded media resides in the /var/www/reviewboard folder. I have fixed the mountpoints and updated the documentation to reflect this.

Hope this helps,

Cheers,
André 