### PR TITLE
Run rb-site upgrade when ReviewBoard upgrade is detected

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN set -ex; \
     if [ "${RB_VERSION}" ]; then RB_VERSION="==${RB_VERSION}"; fi; \
     python -m virtualenv --system-site-packages /opt/venv; \
     . /opt/venv/bin/activate; \
-    pip install "ReviewBoard${RB_VERSION}" 'django-storages<1.3'; \
+    pip install "ReviewBoard${RB_VERSION}" 'django-storages<1.3' semver; \
     rm -rf /root/.cache
 
 ENV PATH="/opt/venv/bin:${PATH}"
@@ -24,8 +24,9 @@ ENV PATH="/opt/venv/bin:${PATH}"
 ADD start.sh /start.sh
 ADD uwsgi.ini /uwsgi.ini
 ADD shell.sh /shell.sh
+ADD upgrade-site.py /upgrade-site.py
 
-RUN chmod +x start.sh shell.sh
+RUN chmod +x /start.sh /shell.sh /upgrade-site.py
 
 VOLUME ["/root/.ssh", "/media/"]
 

--- a/README.md
+++ b/README.md
@@ -121,3 +121,8 @@ For example, if you use ```postfix```, you should change ```/etc/postfix/main.cf
 
     mynetworks = 127.0.0.0/8 [::ffff:127.0.0.0]/104 [::1]/128 172.17.0.0/16
     inet_interfaces = 127.0.0.1,172.17.42.1
+
+## Upgrading
+
+Upgrading to a new ReviewBoard version is as simple as pulling and running the latest image (or use a specific tag).
+The upgrade will be detected at runtime and `rb-site upgrade` will be executed. See: https://www.reviewboard.org/docs/manual/dev/admin/upgrading/upgrading-sites

--- a/start.sh
+++ b/start.sh
@@ -57,6 +57,9 @@ if [[ ! -d /var/www/reviewboard ]]; then
         --admin-user=admin --admin-password=admin --admin-email=admin@example.com \
         /var/www/reviewboard/
 fi
+
+/upgrade-site.py /var/www/reviewboard/rb-version /var/www/reviewboard
+
 if [[ "${DEBUG}" ]]; then
     sed -i 's/DEBUG *= *False/DEBUG=True/' "$CONFFILE"
     cat "${CONFFILE}"

--- a/upgrade-site.py
+++ b/upgrade-site.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+
+import sys
+import subprocess
+import semver
+import reviewboard
+
+
+def main(version_file, site_folder):
+    running_version = reviewboard.get_version_string()
+
+    try:
+        with open(version_file) as f:
+            previous_version = f.readline().strip()
+    except IOError:
+        previous_version = "0.0.0"
+
+    if semver.compare(running_version, previous_version) == 1:
+        print("ReviewBoard upgrade detected, performing rb-site upgrade")
+        subprocess.check_call(["rb-site", "upgrade", site_folder])
+        with open(version_file, 'w') as f:
+            f.write(running_version)
+
+
+if __name__ == "__main__":
+    main(*sys.argv[1:])


### PR DESCRIPTION
Upgrading a site after a ReviewBoard upgrade was a bit of a hassle. This pull request implements automatic migration of the site when a ReviewBoard upgrade is detected.