### PR TITLE
Update uwsgi.ini to use multiple processes on a multi-core host

### DIFF
--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -12,3 +12,5 @@ static-map=$(SITE_ROOT)media=/var/www/reviewboard/htdocs/media
 static-map=$(SITE_ROOT)errordocs=/var/www/reviewboard/htdocs/errordocs
 static-safe=/opt/venv/lib/python2.7/site-packages/
 enable-threads=true
+processes=%k
+


### PR DESCRIPTION
As suggested by Christian Hammond in https://groups.google.com/forum/#!topic/reviewboard/SOn5c1BFE00

The 'processes' property is set to %k meaning the number of cores. See https://uwsgi-docs.readthedocs.io/en/latest/Configuration.html#magic-variables.